### PR TITLE
Set up dependabot for python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,9 @@ updates:
       interval: "daily"
     labels:
       - "infra"
+  - package-ecosystem: "pip"
+    directory: "/src/recommendationservice"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"


### PR DESCRIPTION
Add dependabot configuration for Python dependencies.

* Add a new entry for the Python ecosystem in `.github/dependabot.yml`
  - Set the directory to `src/recommendationservice`
  - Set the schedule interval to `daily`
  - Add a label `dependencies`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CharlieTLe/opentelemetry-demo/pull/72?shareId=37776b90-8b36-4d19-b5de-538bbcfc9410).